### PR TITLE
Correct variable name error for put http request

### DIFF
--- a/controllers/transactionsController.js
+++ b/controllers/transactionsController.js
@@ -110,7 +110,7 @@ transactions.put("/:id", async (req, res) => {
 				.status(404)
 				.json({ error: `could not find student with id: ${id}` });
 		}
-		res.status(200).json({ data: updateTransaction });
+		res.status(200).json({ data: updatedTransaction });
 	} catch (error) {
 		res.status(500).json({ error: error.message });
 	}


### PR DESCRIPTION
Correct variable name storing query result for `put` http request from `updateTransaction` to `updatedTransaction` since query response is stored in variable `updatedTransaction` not `updateTransaction`