### PR TITLE
Add id property to TRANSACTION_FIELDS object for transaction validation

### DIFF
--- a/controllers/transactionsController.js
+++ b/controllers/transactionsController.js
@@ -10,6 +10,7 @@ const {
 const transactions = express.Router();
 
 const TRANSACTION_FIELDS = {
+	id: true,
 	current_user_id: true,
 	transaction_amount: true,
 	transaction_date: true,


### PR DESCRIPTION
When a PUT request was previously made, the transaction was not being updated because it had the `id` property and this was not a property that was part of the TRANSACTION_FIELDS object, thus making the transaction format invalid, and not allowing the PUT request to go through.  

Solution:
- Added the `id` property to `TRANSACTION_FIELDS` To ensure that PUT request get properly validated when updated. 